### PR TITLE
Release 1.1.0.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus OpenTelemetry Exporters
 release:
-  current-version: "1.0.0.Final"
+  current-version: "1.1.0.Final"
   next-version: "999-SNAPSHOT"
 


### PR DESCRIPTION
- [Simplify span processors. (](https://github.com/quarkiverse/quarkus-opentelemetry-exporter/commit/9d1679c8bdd8dce226d2917d2c0564a844a3600f)
- [Google exporter](https://github.com/quarkiverse/quarkus-opentelemetry-exporter/commit/711fb99d8ba56d6f45564f48e1f842ad2c440db6)
- [fix native build (](https://github.com/quarkiverse/quarkus-opentelemetry-exporter/commit/7f8a873743457fd332194c1026476a2fc6d906aa)
- Multiple lib upgrades

Version based on Quarkus 2.16.5.Final under OTel 1.21.0