### PR TITLE
Release 3.16.2.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus OpenTelemetry Exporters
 release:
-  current-version: "3.15.1.0"
+  current-version: "3.16.2.0"
   next-version: "999-SNAPSHOT"
 


### PR DESCRIPTION
Will allow access to OpenTelemetry Logging, available on `quarkus-opentelemetry` since 3.16.