### PR TITLE
Upgraded quarkus-azure-services-bom to 1.1.1 (last Quarkus 3.17 version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
         <gcp-opentelemetry.version>0.33.0</gcp-opentelemetry.version>
 
         <azure-monitor-opentelemetry-autoconfigure.version>1.1.0</azure-monitor-opentelemetry-autoconfigure.version>
-        <quarkus-azure-services-bom.version>1.1.1</quarkus-azure-services-bom.version>
 
         <assertj-core.version>3.27.3</assertj-core.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
         <gcp-opentelemetry.version>0.33.0</gcp-opentelemetry.version>
 
-        <azure-monitor-opentelemetry-autoconfigure.version>1.0.0-beta.2</azure-monitor-opentelemetry-autoconfigure.version>
-        <quarkus-azure-services-bom.version>1.0.2</quarkus-azure-services-bom.version>
+        <azure-monitor-opentelemetry-autoconfigure.version>1.1.0</azure-monitor-opentelemetry-autoconfigure.version>
+        <quarkus-azure-services-bom.version>1.1.1</quarkus-azure-services-bom.version>
 
         <assertj-core.version>3.26.3</assertj-core.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <gcp-opentelemetry.version>0.33.0</gcp-opentelemetry.version>
 
-        <azure-monitor-opentelemetry-autoconfigure.version>1.1.0</azure-monitor-opentelemetry-autoconfigure.version>
+        <azure-monitor-opentelemetry-autoconfigure.version>1.2.0</azure-monitor-opentelemetry-autoconfigure.version>
 
         <assertj-core.version>3.27.3</assertj-core.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>

--- a/quarkus-opentelemetry-exporter-azure/deployment/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/deployment/AzureExporterProcessor.java
+++ b/quarkus-opentelemetry-exporter-azure/deployment/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/deployment/AzureExporterProcessor.java
@@ -69,6 +69,8 @@ public class AzureExporterProcessor {
                 new RuntimeInitializedClassBuildItem("com.azure.core.http.vertx.VertxHttpClientBuilder$DefaultVertx"));
         runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
                 "com.azure.monitor.opentelemetry.autoconfigure.implementation.quickpulse.QuickPulseDataCollector"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "com.azure.monitor.opentelemetry.autoconfigure.implementation.heartbeat.HeartbeatDefaultPayload"));
     }
 
     @BuildStep

--- a/quarkus-opentelemetry-exporter-azure/deployment/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/deployment/AzureExporterProcessor.java
+++ b/quarkus-opentelemetry-exporter-azure/deployment/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/deployment/AzureExporterProcessor.java
@@ -64,9 +64,11 @@ public class AzureExporterProcessor {
         runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem("io.netty.internal.tcnative.SSL"));
         runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem("io.netty.util.concurrent.GlobalEventExecutor"));
         runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
-                "com.azure.core.http.vertx.VertxAsyncHttpClientProvider$GlobalVertxHttpClient"));
+                "com.azure.core.http.vertx.VertxHttpClientProvider$GlobalVertxHttpClient"));
         runtimeInitializedClasses.produce(
-                new RuntimeInitializedClassBuildItem("com.azure.core.http.vertx.VertxAsyncHttpClientBuilder$DefaultVertx"));
+                new RuntimeInitializedClassBuildItem("com.azure.core.http.vertx.VertxHttpClientBuilder$DefaultVertx"));
+        runtimeInitializedClasses.produce(new RuntimeInitializedClassBuildItem(
+                "com.azure.monitor.opentelemetry.autoconfigure.implementation.quickpulse.QuickPulseDataCollector"));
     }
 
     @BuildStep

--- a/quarkus-opentelemetry-exporter-azure/runtime/pom.xml
+++ b/quarkus-opentelemetry-exporter-azure/runtime/pom.xml
@@ -15,7 +15,7 @@
       <dependency>
         <groupId>io.quarkiverse.azureservices</groupId>
         <artifactId>quarkus-azure-services-bom</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
+++ b/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.opentelemetry.runtime.config.build.ExporterType;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -14,6 +13,7 @@ import com.azure.monitor.opentelemetry.autoconfigure.AzureMonitorAutoConfigure;
 
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.quarkus.opentelemetry.runtime.AutoConfiguredOpenTelemetrySdkBuilderCustomizer;
+import io.quarkus.opentelemetry.runtime.config.build.ExporterType;
 
 @Singleton
 public class AzureMonitorCustomizer implements AutoConfiguredOpenTelemetrySdkBuilderCustomizer {
@@ -34,7 +34,8 @@ public class AzureMonitorCustomizer implements AutoConfiguredOpenTelemetrySdkBui
             AzureMonitorAutoConfigure.customize(sdkBuilder, connectionString.get());
         } else {
             sdkBuilder.addPropertiesSupplier(() -> {
-                Map<String, String> props = new HashMap();
+                Map<String, String> props = new HashMap<>();
+                props.put("applicationinsights.live.metrics.enabled", "false");
                 props.put("otel.traces.exporter", ExporterType.NONE.getValue());
                 props.put("otel.metrics.exporter", ExporterType.NONE.getValue());
                 props.put("otel.logs.exporter", ExporterType.NONE.getValue());

--- a/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
+++ b/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.opentelemetry.exporter.azure.runtime;
 
+import java.util.Collections;
+
 import jakarta.inject.Singleton;
 
 import com.azure.monitor.opentelemetry.autoconfigure.AzureMonitorAutoConfigure;
@@ -18,6 +20,7 @@ public class AzureMonitorCustomizer implements AutoConfiguredOpenTelemetrySdkBui
 
     @Override
     public void customize(AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder) {
+        sdkBuilder.addPropertiesSupplier(() -> Collections.singletonMap("applicationinsights.live.metrics.enabled", "false"));
         AzureMonitorAutoConfigure.customize(sdkBuilder, azureConnectionString);
     }
 }

--- a/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
+++ b/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.opentelemetry.exporter.azure.runtime;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import jakarta.inject.Singleton;
@@ -25,7 +26,8 @@ public class AzureMonitorCustomizer implements AutoConfiguredOpenTelemetrySdkBui
     @Override
     public void customize(AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder) {
         if (connectionString.isPresent()) {
-            sdkBuilder.addPropertiesSupplier(() -> Collections.singletonMap("applicationinsights.live.metrics.enabled", "false"));
+            sdkBuilder
+                    .addPropertiesSupplier(() -> Collections.singletonMap("applicationinsights.live.metrics.enabled", "false"));
             AzureMonitorAutoConfigure.customize(sdkBuilder, connectionString.get());
         } else {
             log.info(


### PR DESCRIPTION
Hi,

I have upgraded quarkus-azure-services-bom to 1.1.1. I have chosen this version because it is the last version which is build on Quarkus 3.17.

I noticed a conflict between the `quarkus-opentelemetry-exporter-azure` and Quarkus Camel artifacts (for instance camel-quarkus-azure-storage-blob). The Camel artifacts use `azure-core-http-vertx-1.0.0-beta.24.jar` which does not contain `com.azure.core.http.vertx.VertxAsyncHttpClientProvider` and `com.azure.core.http.vertx.VertxAsyncHttpClientBuilder`. However this extension still uses an older version (through quarkus-azure-services-bom) which causes a native build conflict: `java.lang.ClassNotFoundException: com.azure.core.http.vertx.VertxAsyncHttpClientProvider$GlobalVertxHttpClient`

I have also added one more runtime initialisation for `com.azure.monitor.opentelemetry.autoconfigure.implementation.quickpulse.QuickPulseDataCollector`. Our native build failed because of this class. This classes uses a system MBean.

I hope you can review this PR and let me know if I need to do anything else.

Please see other PR's #322 #305. This might also help with issue #198