### PR TITLE
Set the export to none if no Azure connection string

### DIFF
--- a/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
+++ b/quarkus-opentelemetry-exporter-azure/runtime/src/main/java/io/quarkiverse/opentelemetry/exporter/azure/runtime/AzureMonitorCustomizer.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.opentelemetry.exporter.azure.runtime;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import io.quarkus.opentelemetry.runtime.config.build.ExporterType;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -27,6 +30,13 @@ public class AzureMonitorCustomizer implements AutoConfiguredOpenTelemetrySdkBui
         if (connectionString.isPresent()) {
             AzureMonitorAutoConfigure.customize(sdkBuilder, connectionString.get());
         } else {
+            sdkBuilder.addPropertiesSupplier(() -> {
+                Map<String, String> props = new HashMap();
+                props.put("otel.traces.exporter", ExporterType.NONE.getValue());
+                props.put("otel.metrics.exporter", ExporterType.NONE.getValue());
+                props.put("otel.logs.exporter", ExporterType.NONE.getValue());
+                return props;
+            });
             log.info(
                     "Quarkus Opentelemetry Exporter for Microsoft Azure is not enabled because no Application Insights connection string provided.");
         }


### PR DESCRIPTION
If no Azure connection string is provided, then the `otel.traces.exporter`, `otel.metrics.exporter`, `otel.logs.exporter` properties are set to `cdi`:

![image](https://github.com/user-attachments/assets/ea2c3734-0ed2-4522-8866-2fdbd5db3418)

This PR sets these properties to `none` if no Azure connection string is provided. It may be safer and might avoid an issue when the CDI export value will be removed: https://github.com/quarkusio/quarkus/blob/3e8ab192f3f21883e3e63e7965929df6736b003b/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/config/build/ExporterType.java#L8

cc @brunobat 